### PR TITLE
feat: add documentation and improve adapters for modechar.nvim

### DIFF
--- a/doc/modechar.nvim.txt
+++ b/doc/modechar.nvim.txt
@@ -1,0 +1,178 @@
+==============================================================================
+Modes                                                    *modechar.modhal.modes*
+
+ Defines the modes recognized by the modahl plugin. Neovim native mode strings are mapped to these values.
+
+Mode                                                                      *Mode*
+
+    Values: ~
+        UNDEFINED
+        NORMAL
+        INSERT
+        VISUAL
+        VISUAL_LINE
+        VISUAL_BLOCK
+        REPLACE
+        COMMAND
+        SELECT
+        TERMINAL
+
+
+==============================================================================
+Introduction                                                   *modechar.modahl*
+
+Modahl: A module that dynamically updates highlight groups based on mode changes.
+
+Create new highlight groups and link them to existing ones, updating them based on the current mode in Neovim.
+The atttributes for the highlight group updates are provided by the adapter. Three known adapters
+are provided: "debug", "lualine", and "lualine-invert". The "debug" adapter is the default if not configured.
+
+The known adapters are configured by name:
+>
+{
+  "MyOtherHighlightIsAPorche",
+  adapter = "lualine",
+}
+<
+
+>
+ A custom adapter can easily be created inline:
+{
+  "MyCustomGroup",
+  ---@type ModahlAdapter
+  adapter = {
+    name = "MyCustomAdapter",
+    on_mode_change = function(prev, curr, config)
+      local modes = require("modahl.modes")
+      if curr == modes.NORMAL then
+        return { fg = "red", bg = "blue" }
+      elseif curr == modes.INSERT then
+        return { fg = "green", bg = "yellow" }
+      else
+        return { fg = "white", bg = "black" }
+      end
+    end,
+  },
+}
+<
+
+==============================================================================
+Types                                                          *modechar.modahl*
+
+ModahlAdapter                                                    *ModahlAdapter*
+
+    Fields: ~
+        {name}            (string)                                                                      -- the name of the adapter
+        {on_mode_change}  (fun(prev:Mode,curr:Mode,config:ModahlOptions):vim.api.keyset.highlight|nil)  -- callback function
+
+
+HighlightGroupDefinition                              *HighlightGroupDefinition*
+
+    Fields: ~
+        {1?}        (string)                                            -- the name of the highlight group to create and keep updated
+        {adapter?}  (ModahlAdapter|"debug"|"lualine"|"lualine-invert")  -- the adapter to use for this group
+        {links?}    (string[])                                          -- a list of highlight groups to link to this group
+
+
+ModahlOptions                                                    *ModahlOptions*
+
+    Fields: ~
+        {highlights?}     (HighlightGroupDefinition[])  -- a list of highlight groups to create and keep updated
+        {autocmd_group?}  (string)                      -- the name of the autocommand group to create
+        {mode_map?}       (table<string,Mode>)          -- a map of Neovim modes to Modahl modes
+        {debug?}          (boolean|"verbose")           -- whether to enable debug logging
+
+
+==============================================================================
+Module                                                         *modechar.modahl*
+
+ModahlModule                                                      *ModahlModule*
+
+
+M.defaults                                                          *M.defaults*
+    Default options.
+
+    Type: ~
+        (ModahlOptions)
+
+
+M.setup({opts})                                                        *M.setup*
+    Initialize the Modahl module with the given options.
+
+    Parameters: ~
+        {opts}  (ModahlOptions|{})
+
+
+==============================================================================
+Introduction                                                 *modechar.modechar*
+
+ModeChar: A module that registers a character (or any string) by name
+with associated window filters and highlights. It can be used to display
+characters in the statusline, tabline, or any other place where you can
+use a string.
+
+>
+vim.o.statuscolumn = [[%!v:lua.require'modechar'.get('gutter') .. v:lua.require'snacks.statuscolumn'.get()]]
+<
+
+==============================================================================
+Types                                                        *modechar.modechar*
+
+CharDef : CharDefFilters                                               *CharDef*
+
+    Fields: ~
+        {1}          (string)                                                    -- the character to show (can be any string)
+        {highlight}  ("ModeCharLualine"|"ModeCharLualineInvert"|"Debug"|string)  -- highlight group name to use for the character.
+        {clear_hl?}  (boolean)                                                   -- whether to clear the highlight providedup after printing the character. default: true
+
+
+CharDefFilters                                                  *CharDefFilters*
+
+    Fields: ~
+        {floats?}    (boolean|string)        -- whether to show the character in floating windows. default: false
+        {inactive?}  (boolean|string)        -- whether to show the character in inactive windows. default: false
+        {buftype?}   (string|string[]|true)  -- a list of buffer types to show the character in. default: "" (normal buffers)
+        {fallback?}  (string)                -- fallback character to use if the ModeChar is excluded by the filters. default: ""
+
+
+ModeCharOptions                                                *ModeCharOptions*
+
+    Fields: ~
+        {chars?}        (table<string,CharDef>|fun(arg:string):CharDef)  -- a table of ModeChar indexed by name or an equivalent function
+        {char_filter?}  (CharDefFilters)                                 -- default filters to use for all characters. default: { floats = false, inactive = false, buftype = { "" = true }, fallback = "" }
+        {debug?}        (boolean|number)                                 -- debug level. default: false
+        {modahl_opts?}  (ModahlOptions)                                  -- options for the Modahl module.
+
+
+==============================================================================
+Module                                                       *modechar.modechar*
+
+ModeCharModule                                                  *ModeCharModule*
+
+
+M.defaults                                                          *M.defaults*
+    Default options.
+
+    Type: ~
+        (ModeCharOptions)
+
+
+M.setup({opts})                                                        *M.setup*
+    Initialize the ModeChar module with the given options.
+
+    Parameters: ~
+        {opts}  (ModeCharOptions|{})
+
+
+M.get({name}, {winid?})                                                  *M.get*
+    Get the character to display by name.
+
+    Parameters: ~
+        {name}    (string)  -- the key of the opts.chars table or the arg to the function
+        {winid?}  (number)  -- provide to check filters against the window, or nil to use g.statusline_winid
+
+    Returns: ~
+        (_)  -- the character to show or the fallback character if excluded by filters
+
+
+vim:tw=78:ts=8:noet:ft=help:norl:

--- a/lua/modahl/debug_adapter.lua
+++ b/lua/modahl/debug_adapter.lua
@@ -1,32 +1,34 @@
---[[
-This adapter maps modes to highly visible colors for debugging purposes.
-]]
+---@mod modechar.modahl Adapters
+---@brief [[
+--- A ModahlAdapter that maps modes to highly visible colors for debugging purposes.
+---@brief ]]
 
-local modes = require("modahl.modes")
+local modes = require('modahl.modes')
 
+---Modahl Debug Adapter
 ---@type ModahlAdapter
 return {
-  name = "debug",
+  name = 'debug',
   on_mode_change = function(_, curr, config)
     local color_map = {
-      [modes.UNDEFINED] = { fg = "bg", bg = "fg" },
-      [modes.NORMAL] = { fg = "#FF0000", bg = "#00FF00" },
-      [modes.INSERT] = { fg = "#FFFF00", bg = "#0000FF" },
-      [modes.VISUAL] = { fg = "#FF00FF", bg = "#00FFFF" },
-      [modes.VISUAL_LINE] = { fg = "#FFA500", bg = "#800080" },
-      [modes.VISUAL_BLOCK] = { fg = "#008000", bg = "#FFC0CB" },
-      [modes.REPLACE] = { fg = "#0000FF", bg = "#FFFF00" },
-      [modes.COMMAND] = { fg = "#00FFFF", bg = "#FF00FF" },
-      [modes.SELECT] = { fg = "#800080", bg = "#FFA500" },
-      [modes.TERMINAL] = { fg = "#FFC0CB", bg = "#008000" },
+      [modes.UNDEFINED] = { fg = 'bg', bg = 'fg' },
+      [modes.NORMAL] = { fg = '#FF0000', bg = '#00FF00' },
+      [modes.INSERT] = { fg = '#FFFF00', bg = '#0000FF' },
+      [modes.VISUAL] = { fg = '#FF00FF', bg = '#00FFFF' },
+      [modes.VISUAL_LINE] = { fg = '#FFA500', bg = '#800080' },
+      [modes.VISUAL_BLOCK] = { fg = '#008000', bg = '#FFC0CB' },
+      [modes.REPLACE] = { fg = '#0000FF', bg = '#FFFF00' },
+      [modes.COMMAND] = { fg = '#00FFFF', bg = '#FF00FF' },
+      [modes.SELECT] = { fg = '#800080', bg = '#FFA500' },
+      [modes.TERMINAL] = { fg = '#FFC0CB', bg = '#008000' },
     }
 
     local color = color_map[curr]
     if not color then
       if config.debug then
-        vim.notify("Invalid mode: " .. tostring(curr), vim.log.levels.ERROR)
+        vim.notify('Invalid mode: ' .. tostring(curr), vim.log.levels.ERROR)
       end
-      return { fg = "NONE", bg = "NONE" }
+      return { fg = 'NONE', bg = 'NONE' }
     end
 
     return color

--- a/lua/modahl/init.lua
+++ b/lua/modahl/init.lua
@@ -1,72 +1,78 @@
---[[
-Modahl: A Neovim plugin for dynamically updating highlight groups based on mode changes.
+---@mod modechar.modahl Introduction
+---@brief [[
+---Modahl: A module that dynamically updates highlight groups based on mode changes.
+---
+---Create new highlight groups and link them to existing ones, updating them based on the current mode in Neovim.
+---The atttributes for the highlight group updates are provided by the adapter. Three known adapters
+---are provided: "debug", "lualine", and "lualine-invert". The "debug" adapter is the default if not configured.
+---
+---The known adapters are configured by name:
+--->
+---{
+---  "MyOtherHighlightIsAPorche",
+---  adapter = "lualine",
+---}
+---<
+---
+--->
+--- A custom adapter can easily be created inline:
+---{
+---  "MyCustomGroup",
+---  ---@type ModahlAdapter
+---  adapter = {
+---    name = "MyCustomAdapter",
+---    on_mode_change = function(prev, curr, config)
+---      local modes = require("modahl.modes")
+---      if curr == modes.NORMAL then
+---        return { fg = "red", bg = "blue" }
+---      elseif curr == modes.INSERT then
+---        return { fg = "green", bg = "yellow" }
+---      else
+---        return { fg = "white", bg = "black" }
+---      end
+---    end,
+---  },
+---}
+---<
+---@brief ]]
 
-Create new highlight groups and link them to existing ones, updating them based on the current mode in Neovim.
-The atttributes for the highlight group updates are provided by the adapter. Three known adapters
-are provided: "debug", "lualine", and "lualine-invert". The "debug" adapter is the default if not configured.
-
-The known adapters are configured by name:
-{
-  "MyOtherHighlightIsAPorche",
-  adapter = "lualine",
-}
-
-A custom adapter can easily be created inline:
-{
-  "MyCustomGroup",
-  ---@type ModahlAdapter
-  adapter = {
-    name = "MyCustomAdapter",
-    on_mode_change = function(prev, curr, config)
-      local modes = require("modahl.modes")
-      if curr == modes.NORMAL then
-        return { fg = "red", bg = "blue" }
-      elseif curr == modes.INSERT then
-        return { fg = "green", bg = "yellow" }
-      else
-        return { fg = "white", bg = "black" }
-      end
-    end,
-  },
-}
-
-]]
+---@mod modechar.modahl Types
 
 ---@class ModahlAdapter
----@field name string
----@field on_mode_change fun(prev: Mode, curr: Mode, config: ModahlOptions): vim.api.keyset.highlight | nil
+---@field name string -- the name of the adapter
+---@field on_mode_change fun(prev: Mode, curr: Mode, config: ModahlOptions): vim.api.keyset.highlight | nil -- callback function
 
 ---@class HighlightGroupDefinition
----@field [1]? string
----@field adapter? ModahlAdapter | "debug" | "lualine" | "lualine-invert"
----@field links? string[]
+---@field [1]? string -- the name of the highlight group to create and keep updated
+---@field adapter? ModahlAdapter | 'debug' | 'lualine' | 'lualine-invert' -- the adapter to use for this group
+---@field links? string[] -- a list of highlight groups to link to this group
 
 ---@class ModahlOptions
----@field highlights? HighlightGroupDefinition[]
----@field autocmd_group? string
----@field mode_map? table<string, Mode>
----@field debug? boolean | "verbose"
+---@field highlights? HighlightGroupDefinition[] -- a list of highlight groups to create and keep updated
+---@field autocmd_group? string -- the name of the autocommand group to create
+---@field mode_map? table<string, Mode> -- a map of Neovim modes to Modahl modes
+---@field debug? boolean | 'verbose' -- whether to enable debug logging
+
+---@mod modechar.modahl Module
 
 ---@class ModahlModule
----@field setup fun(opts: ModahlOptions)
----@field defaults ModahlOptions
----@field config? ModahlOptions
 local M = {}
 
-local modes = require("modahl.modes")
-local known_adapters = { "debug", "lualine", "lualine-invert" }
-local default_hlname = "Modahl"
+local modes = require('modahl.modes')
+local known_adapters = { 'debug', 'lualine', 'lualine-invert' }
+local default_hlname = 'Modahl'
 
+---Default options.
 ---@type ModahlOptions
 M.defaults = {
   highlights = {
     {
       default_hlname,
-      adapter = "debug",
+      adapter = 'debug',
       links = {},
     },
   },
-  autocmd_group = "ModahlGroup",
+  autocmd_group = 'ModahlGroup',
   mode_map = {
     n = modes.NORMAL,
     no = modes.NORMAL,
@@ -75,7 +81,7 @@ M.defaults = {
     ic = modes.INSERT,
     v = modes.VISUAL,
     V = modes.VISUAL_LINE,
-    [""] = modes.VISUAL_BLOCK,
+    [''] = modes.VISUAL_BLOCK,
     s = modes.SELECT,
     S = modes.SELECT,
     R = modes.REPLACE,
@@ -86,47 +92,72 @@ M.defaults = {
   debug = false,
 }
 
+---@param config ModahlOptions
 local function setup_mode_change_listener(config)
-  vim.api.nvim_create_autocmd({ "ModeChanged", "BufEnter" }, {
-    group = config.autocmd_group,
-    callback = function()
-      local prev_mode = M.prev_mode or modes.UNDEFINED
-      local curr_mode = config.mode_map[vim.fn.mode()] or nil
+  vim.api.nvim_create_autocmd(
+    { 'ModeChanged', 'BufEnter', 'BufLeave', 'ColorScheme', 'BufWinEnter', 'BufWinLeave', 'WinEnter', 'WinLeave' },
+    {
+      group = config.autocmd_group,
+      callback = function()
+        local prev_mode = M.prev_mode or modes.UNDEFINED
+        local curr_mode = config.mode_map[vim.fn.mode()] or nil
 
-      if not prev_mode or not curr_mode then
-        if config.debug then
-          vim.notify(
-            "Invalid mode change detected: " .. (prev_mode or "nil old_mode") .. " -> " .. (curr_mode or "nil new_mode"),
-            vim.log.levels.WARN
-          )
-        end
-        return
-      end
-
-      for _, group in ipairs(config.highlights) do
-        local adapter = group.adapter
-        local attributes = adapter.on_mode_change(prev_mode, curr_mode, config)
-        if attributes then
-          if config.debug == "verbose" then
+        if not prev_mode or not curr_mode then
+          if config.debug then
             vim.notify(
-              "Adapter "
-                .. (group.adapter.name or "unnamed adapter")
-                .. " returned attributes for mode change: "
+              'Invalid mode change detected: '
+                .. (prev_mode or 'nil prev_mode')
+                .. ' -> '
+                .. (curr_mode or 'nil curr_mode'),
+              vim.log.levels.WARN
+            )
+          end
+          return
+        end
+
+        M.prev_mode = curr_mode
+
+        for _, group in ipairs(config.highlights) do
+          local adapter = group.adapter
+          if not adapter then
+            vim.notify('No adapter found for group: ' .. group[1], vim.log.levels.ERROR)
+            return
+          end
+          local ok, attributes = pcall(adapter.on_mode_change, prev_mode, curr_mode, config)
+          if not ok then
+            if config.debug then
+              vim.notify(
+                'Adapter ' .. group.adapter.name .. ' failed to return attributes: ' .. attributes,
+                vim.log.levels.ERROR
+              )
+            end
+            return
+          end
+
+          if not attributes then
+            if config.debug == 'verbose' then
+              vim.notify('Adapter ' .. group.adapter.name .. ' did not return attributes', vim.log.levels.TRACE)
+            end
+            return
+          end
+
+          if config.debug == 'verbose' then
+            vim.notify(
+              'Adapter '
+                .. (group.adapter.name or 'unnamed adapter')
+                .. ' returned attributes for mode change: '
                 .. vim.inspect(attributes),
               vim.log.levels.TRACE
             )
           end
+
           vim.schedule(function()
             vim.api.nvim_set_hl(0, group[1], attributes)
           end)
-        elseif config.debug == "verbose" then
-          vim.notify("Adapter " .. group.adapter .. " did not return attributes for mode change", vim.log.levels.TRACE)
         end
-      end
-
-      M.prev_mode = curr_mode
-    end,
-  })
+      end,
+    }
+  )
 end
 
 ---@param config ModahlOptions
@@ -138,24 +169,37 @@ local function setup_highlight_groups(config)
     local links = group.links
 
     if not group_name then
-      vim.notify("Invalid highlight group name", vim.log.levels.ERROR)
+      vim.notify('Invalid highlight group name', vim.log.levels.ERROR)
       return
     end
 
     if not adapter then
-      vim.notify("Invalid adapter for group: " .. group_name, vim.log.levels.ERROR)
+      vim.notify('Invalid adapter for group: ' .. group_name, vim.log.levels.ERROR)
       return
     end
 
     local mode = config.mode_map[vim.fn.mode()] or modes.UNDEFINED
     if mode == modes.UNDEFINED and config.debug then
-      vim.notify("Invalid mode for group: " .. group_name, vim.log.levels.DEBUG)
+      vim.notify('Invalid mode for group: ' .. group_name, vim.log.levels.DEBUG)
     end
 
-    local hl_attributes = adapter.on_mode_change(modes.UNDEFINED, mode, config) or { fg = "NONE", bg = "NONE" }
+    local ok, attributes = pcall(adapter.on_mode_change, modes.UNDEFINED, mode, config)
+    if not ok then
+      if config.debug then
+        vim.notify('Adapter ' .. adapter.name .. ' failed to return attributes: ' .. attributes, vim.log.levels.ERROR)
+      end
+      return
+    end
+
+    if not attributes then
+      if config.debug == 'verbose' then
+        vim.notify('Adapter ' .. adapter.name .. ' did not return attributes', vim.log.levels.TRACE)
+      end
+      return
+    end
 
     -- Define the highlight group
-    vim.api.nvim_set_hl(0, group_name, hl_attributes)
+    vim.api.nvim_set_hl(0, group_name, attributes)
 
     -- Set up links for the highlight group
     for _, link in ipairs(links or {}) do
@@ -164,34 +208,34 @@ local function setup_highlight_groups(config)
   end
 end
 
--- Setup function to initialize Modahl
----@param opts ModahlOptions
+---Initialize the Modahl module with the given options.
+---@param opts ModahlOptions | {}
 function M.setup(opts)
   -- Merge user options with defaults
-  local config = vim.tbl_deep_extend("force", {}, M.defaults, opts or {})
+  local config = vim.tbl_deep_extend('force', {}, M.defaults, opts or {})
 
   for _, group in ipairs(config.highlights) do
     local adapter = group.adapter
 
-    if type(group[1]) ~= "string" then
+    if type(group[1]) ~= 'string' then
       if config.debug then
-        vim.notify("Using default highlight group name " .. default_hlname, vim.log.levels.DEBUG)
+        vim.notify('Using default highlight group name ' .. default_hlname, vim.log.levels.DEBUG)
       end
       group[1] = default_hlname
     end
 
-    if type(adapter) ~= "table" or not adapter.on_mode_change then
-      if type(adapter) == "string" and vim.tbl_contains(known_adapters, adapter) then
-        group.adapter = require("modahl." .. group.adapter .. "_adapter")
+    if type(adapter) ~= 'table' or not adapter.on_mode_change then
+      if type(adapter) == 'string' and vim.tbl_contains(known_adapters, adapter) then
+        group.adapter = require('modahl.' .. group.adapter .. '_adapter')
       else
-        group.adapter = require("modahl.debug_adapter")
-        vim.notify("Invalid adapter for group: " .. group[1], vim.log.levels.ERROR)
+        group.adapter = require('modahl.debug_adapter')
+        vim.notify('Invalid adapter for group: ' .. group[1], vim.log.levels.ERROR)
       end
     end
   end
 
   if config.debug then
-    vim.notify("Modahl: setup() with options: " .. vim.inspect(config), vim.log.levels.DEBUG)
+    vim.notify('Modahl: setup() with options: ' .. vim.inspect(config), vim.log.levels.DEBUG)
   end
 
   -- Set up highlight groups

--- a/lua/modahl/lualine-invert_adapter.lua
+++ b/lua/modahl/lualine-invert_adapter.lua
@@ -1,18 +1,20 @@
---[[
-This adapter inverts the colors of the lualine theme.
-]]
+---@mod modechar.modahl Adapters
+---@brief [[
+--- A ModahlAdapter that inverts the colors of the lualine theme.
+---@brief ]]
 
-local lualine_adapter = require("modahl.lualine_adapter")
+local lualine_adapter = require('modahl.lualine_adapter')
 
+---Modahl lualine inverted adapter
 ---@type ModahlAdapter
 return {
-  name = "lualine-invert",
+  name = 'lualine-invert',
   on_mode_change = function(_, curr, config)
     local base = lualine_adapter.on_mode_change(_, curr, config)
     if base then
-      return { fg = base.bg, bg = "NONE" }
+      return { fg = base.bg, bg = 'NONE' }
     elseif config.debug then
-      vim.notify("lualine-invert: no base color found", vim.log.levels.WARN)
+      vim.notify('lualine-invert: no base color found', vim.log.levels.WARN)
     end
 
     return nil

--- a/lua/modahl/lualine_adapter.lua
+++ b/lua/modahl/lualine_adapter.lua
@@ -1,43 +1,44 @@
---[[
-This adapter retrieves the colors from the lualine 'a' section mode groups.
-]]
+---@mod modechar.modahl Adapters
+---@brief [[
+--- A ModahlAdapter that retrieves the colors from the lualine 'a' section mode groups.
+---@brief ]]
 
-local modes = require("modahl.modes")
+local modes = require('modahl.modes')
 
 -- Mode to lualine mapping
 ---@param mode Mode
 ---@return string | nil
 local function mode_to_lualine(mode)
   local mode_map = {
-    [modes.UNDEFINED] = "normal",
-    [modes.NORMAL] = "normal",
-    [modes.INSERT] = "insert",
-    [modes.VISUAL] = "visual",
-    [modes.VISUAL_LINE] = "visual",
-    [modes.VISUAL_BLOCK] = "visual",
-    [modes.SELECT] = "visual",
-    [modes.REPLACE] = "replace",
-    [modes.COMMAND] = "command",
-    [modes.TERMINAL] = "insert",
+    [modes.UNDEFINED] = 'normal',
+    [modes.NORMAL] = 'normal',
+    [modes.INSERT] = 'insert',
+    [modes.VISUAL] = 'visual',
+    [modes.VISUAL_LINE] = 'visual',
+    [modes.VISUAL_BLOCK] = 'visual',
+    [modes.SELECT] = 'visual',
+    [modes.REPLACE] = 'replace',
+    [modes.COMMAND] = 'command',
+    [modes.TERMINAL] = 'insert',
   }
   return mode_map[mode]
 end
 
+---Modal lualine adapter
 ---@type ModahlAdapter
 return {
-  name = "lualine",
+  name = 'lualine',
 
-  ---@param curr Mode
   on_mode_change = function(_, curr, config)
     local lualine_mode = mode_to_lualine(curr)
     if not lualine_mode then
       if config.debug then
-        vim.notify("Unmapped lualine mode: " .. tostring(curr), vim.log.levels.WARN)
+        vim.notify('Unmapped lualine mode: ' .. tostring(curr), vim.log.levels.WARN)
       end
-      lualine_mode = "normal"
+      lualine_mode = 'normal'
     end
 
-    local lualine_group = "lualine_a_" .. lualine_mode
+    local lualine_group = 'lualine_a_' .. lualine_mode
     local ok, hl = pcall(vim.api.nvim_get_hl, 0, { name = lualine_group, link = false })
 
     if ok and hl then
@@ -45,9 +46,9 @@ return {
     end
 
     if config.debug then
-      vim.notify("Failed to get lualine mode color for group: " .. lualine_group, vim.log.levels.WARN)
+      vim.notify('Failed to get lualine mode color for group: ' .. lualine_group, vim.log.levels.WARN)
     end
 
-    return { fg = "NONE", bg = "NONE" }
+    return { fg = 'NONE', bg = 'NONE' }
   end,
 }

--- a/lua/modahl/modes.lua
+++ b/lua/modahl/modes.lua
@@ -1,4 +1,7 @@
--- Defines the modes recognized by the modahl plugin. Neovim native mode strings are mapped to these values.
+---@mod modechar.modhal.modes Modes
+---@brief [[
+--- Defines the modes recognized by the modahl plugin. Neovim native mode strings are mapped to these values.
+---@brief ]]
 
 ---@enum Mode
 local mode = {

--- a/mise.toml
+++ b/mise.toml
@@ -1,0 +1,2 @@
+[tools]
+cargo = "latest"

--- a/stylua.toml
+++ b/stylua.toml
@@ -1,5 +1,6 @@
 indent_type = "Spaces"
 indent_width = 2
 column_width = 120
+quote_style = "AutoPreferSingle"
 [sort_requires]
 enabled = true

--- a/tools/doc.sh
+++ b/tools/doc.sh
@@ -1,0 +1,16 @@
+#!/bin/sh
+
+# Generate documentation for the modechar.nvim plugin using vimcats.
+# Run this script from the root of the repository:
+# $ sh tools/docs.sh
+
+mkdir -p "$PWD/doc"
+cargo install vimcats --features=cli
+vimcats lua/modahl/modes.lua \
+  lua/modahl/init.lua \
+  lua/modahl/debug_adapter.lua \
+  lua/modahl/lualine_adapter.lua \
+  lua/modahl/lualine-invert_adapter.lua \
+  lua/modechar/init.lua >"$PWD/doc/modechar.nvim.txt"
+
+less "$PWD/doc/modechar.nvim.txt"


### PR DESCRIPTION
- Added `doc/modechar.nvim.txt` to provide detailed documentation for the `modechar.nvim` plugin, including modes, adapters, and usage examples.
- Enhanced `debug_adapter.lua`, `lualine_adapter.lua`, and `lualine-invert_adapter.lua` with improved comments and error handling.
- Updated `init.lua` files for `modahl` and `modechar` modules with better type annotations and configuration validation.
- Introduced `mise.toml` for tool configuration and updated `stylua.toml` to prefer single quotes.
- Added `tools/doc.sh` script to automate documentation generation using `vimcats`.

This commit improves usability, maintainability, and documentation for the plugin.